### PR TITLE
fix: `Ident` translation

### DIFF
--- a/zang-macro/src/lib.rs
+++ b/zang-macro/src/lib.rs
@@ -67,7 +67,7 @@ fn replace_ident(ident: Ident) -> Option<TokenTree> {
         "ha" => "true",
         "tur" => "enum",
         "Guruh" => "Group",
-        "Identatsiya" => "Ident",
+        "Identifikator" => "Ident",
         "TokenOqim" => "TokenStream",
         "TokenDaraxt" => "TokenTree",
         "matnga" => "to_string",


### PR DESCRIPTION
Ident - Identifier. Not an Indentation.

See: https://doc.rust-lang.org/proc_macro/struct.Ident.html